### PR TITLE
Fix some issues with watch hook

### DIFF
--- a/org-tanglesync.el
+++ b/org-tanglesync.el
@@ -460,23 +460,17 @@ Uses `org-tanglesync-watch-files` to generate.")
   "A hook to update current buffer contents in the source org file.
 Takes the current contents of the saved file and sync them back to
 the source org file they are originally tangled to."
-  (when (and org-tanglesync-watch-files org-tanglesync-watch-mode)
-    (let ((tfile buffer-file-name)
-          ;;(org-tanglesync-confmap
-          ;; (org-tanglesync-watch-make-watchlist
-          ;;  org-tanglesync-watch-files))
-          ;; -- this should already be initialised, though the issue is
-          ;;    when do we update it?
-          (contbuff (org-tanglesync-get-filedata-buffer buffer-file-name)))
-      (let ((cfile (org-tanglesync-watch-get-conf-source
-                    tfile
-                    org-tanglesync-confmap)))
-        (when cfile
-          (org-tanglesync-watch-perform-sync tfile cfile contbuff)
-          (kill-buffer contbuff))))))
 
 (add-hook 'after-save-hook #'org-tanglesync-watch-save)
 (add-hook 'org-src-mode-hook #'org-tanglesync-user-edit-buffer)
+(when org-tanglesync-watch-files
+  (let* ((tfile buffer-file-name)
+         (cfile (org-tanglesync-watch-get-conf-source
+                 tfile
+                 org-tanglesync-confmap)))
+    (when cfile
+      (org-tanglesync-watch-perform-sync
+       tfile cfile (org-tanglesync-get-filedata-buffer buffer-file-name))))))
 
 (provide 'org-tanglesync)
 ;;; org-tanglesync.el ends here

--- a/org-tanglesync.el
+++ b/org-tanglesync.el
@@ -454,11 +454,11 @@ Uses `org-tanglesync-watch-files` to generate.")
         (org-tanglesync-watch-perform-sync tfile cfile)
       (message "Could not find config file for %s." tfile))))
 
-(defun org-tanglesync-watch-perform-sync (tfile cfile contents)
-  "Take CONTENTS from TFILE and place them into the CFILE config."
+(defun org-tanglesync-watch-perform-sync (tfile cfile content-buffer)
+  "Take CONTENT-BUFFER from TFILE and place them into the CFILE config."
   (let ((cbuff (find-file-noselect cfile))
          (tpos (org-tanglesync-watch-get-tfile-pos tfile cfile)))
-    (org-tanglesync-perform-overwrite t contents cbuff tpos)
+    (org-tanglesync-perform-overwrite t content-buffer cbuff tpos)
     (message "Synced %s to %s" tfile cfile)))
 
 (defun org-tanglesync-watch-save ()
@@ -472,7 +472,7 @@ the source org file they are originally tangled to."
                    org-tanglesync-confmap)))
       (when cfile
         (org-tanglesync-watch-perform-sync
-         tfile cfile (org-tanglesync-get-filedata-buffer buffer-file-name))))))
+         tfile cfile (current-buffer))))))
 
 (provide 'org-tanglesync)
 ;;; org-tanglesync.el ends here


### PR DESCRIPTION
Two Things here:

When `org-tanglesync-watch-mode` is enabled it was making a copy of every buffer every time it was saved. There is no need to do that since there are very few files that we will actually need to make a copy. Imaging trying to save a 1 gig log file only to have emacs make a copy of it each time. We should only make copies of files we know we will need (Though to be entirely honest not sure why it is making a copy in the first place instead of just fetching the original buffer). 

Loading a package should never add hooks to the user config unless the user enables them. I moved the hooks into minor modes. If users follow the setup you give the behavior will be the same.

